### PR TITLE
Remove unnecessary use of dynamic binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ namespace MyFunctionApp
             
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 correlationId = context.TraceIdentifier,
                 body = context.Items[ContextItems.Body],

--- a/samples/ConditionalMiddleware/Functions/Functions.cs
+++ b/samples/ConditionalMiddleware/Functions/Functions.cs
@@ -58,7 +58,7 @@ namespace Samples.ConditionalMiddleware.Functions
         {
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 message = "OK",
                 functionName = "Function1"
@@ -76,7 +76,7 @@ namespace Samples.ConditionalMiddleware.Functions
         {
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 message = "OK",
                 functionName = "Function2"

--- a/samples/ExceptionHandler/Pipelines/CustomExceptionHandler.cs
+++ b/samples/ExceptionHandler/Pipelines/CustomExceptionHandler.cs
@@ -20,7 +20,7 @@ namespace Samples.ModelValidation.Pipelines
                     return new StatusCodeResult(429);
 
                 default:
-                    dynamic body = new
+                    var body = new
                     {
                         correlationId = context.TraceIdentifier,
                         error = new

--- a/samples/ModelValidation/Functions/BodyValidation.cs
+++ b/samples/ModelValidation/Functions/BodyValidation.cs
@@ -52,7 +52,7 @@ namespace Samples.ModelValidation.Functions
         {
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 correlationId = context.TraceIdentifier,
                 message = "OK",

--- a/samples/ModelValidation/Functions/QueryValidation.cs
+++ b/samples/ModelValidation/Functions/QueryValidation.cs
@@ -54,7 +54,7 @@ namespace Samples.ModelValidation.Functions
         {
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 correlationId = context.TraceIdentifier,
                 message = "OK",

--- a/samples/PipelineBranching/Functions/Functions.cs
+++ b/samples/PipelineBranching/Functions/Functions.cs
@@ -58,7 +58,7 @@ namespace Samples.PipelineBranching.Functions
         {
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 message = "OK",
                 functionName = "Function1"
@@ -76,7 +76,7 @@ namespace Samples.PipelineBranching.Functions
         {
             await Task.CompletedTask;
 
-            dynamic payload = new
+            var payload = new
             {
                 message = "OK",
                 functionName = "Function2"

--- a/src/Umamimolecule.AzureFunctionsMiddleware/ExceptionHandlerMiddleware.cs
+++ b/src/Umamimolecule.AzureFunctionsMiddleware/ExceptionHandlerMiddleware.cs
@@ -26,7 +26,7 @@ namespace Umamimolecule.AzureFunctionsMiddleware
 
                     if (exception is BadRequestException)
                     {
-                        dynamic response = new
+                        var response = new
                         {
                             correlationId = context.TraceIdentifier,
                             error = new
@@ -40,7 +40,7 @@ namespace Umamimolecule.AzureFunctionsMiddleware
                     }
                     else
                     {
-                        dynamic response = new
+                        var response = new
                         {
                             correlationId = context.TraceIdentifier,
                             error = new
@@ -98,7 +98,7 @@ namespace Umamimolecule.AzureFunctionsMiddleware
                 {
                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
                     context.Response.ContentType = ContentTypes.ApplicationJson;
-                    dynamic content = new
+                    var content = new
                     {
                         error = new
                         {

--- a/src/Umamimolecule.AzureFunctionsMiddleware/ValidationMiddleware.cs
+++ b/src/Umamimolecule.AzureFunctionsMiddleware/ValidationMiddleware.cs
@@ -36,7 +36,7 @@ namespace Umamimolecule.AzureFunctionsMiddleware
             }
             else
             {
-                dynamic response = new
+                var response = new
                 {
                     correlationId = context.TraceIdentifier,
                     error = new

--- a/tests/Umamimolecule.AzureFunctionsMiddleware.Tests/MiddlewarePipelineTests.cs
+++ b/tests/Umamimolecule.AzureFunctionsMiddleware.Tests/MiddlewarePipelineTests.cs
@@ -99,7 +99,7 @@ namespace Umamimolecule.AzureFunctionsMiddleware.Tests
             var instance = this.CreateInstance();
             var middleware = new FunctionMiddleware((HttpContext context) =>
             {
-                dynamic obj = new
+                var obj = new
                 {
                     message = "hello"
                 };


### PR DESCRIPTION
Use of `dynamic` seems unnecessary and introduces dynamic binding at run-time with no added benefit. This PR replaces all occurrences of `dynamic` with `var`, which is statically-typed (albeit anonymous). All tests still pass.
